### PR TITLE
more consistent use of install.xml

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -28,7 +28,6 @@ class Controller extends Package {
     public function install() {
         $pkg = parent::install();
 
-        \Concrete\Core\Job\Job::installByPackage('optimized_images_job', $pkg);
         $this->installXmlContent();
     }
 

--- a/install.xml
+++ b/install.xml
@@ -7,4 +7,7 @@
               package="optimized_images">
         </page>
     </singlepages>
+    <jobs>
+        <job handle="optimized_images_job" package="optimized_images"></job>
+    </jobs>	
 </concrete5-cif>


### PR DESCRIPTION
I'd suggest to always use the XML, this gives us a nice overview of what's in the package
